### PR TITLE
Return the correct default type when no map is stolen

### DIFF
--- a/autoload/clang2.vim
+++ b/autoload/clang2.vim
@@ -218,21 +218,16 @@ endfunction
 
 " Parse a map arg
 function! s:maparg(map, mode, ...) abort
+  let default = {'rhs': a:0 ? a:1 : a:map, 'expr': 0}
   let arg = maparg(a:map, a:mode, 0, 1)
   if empty(arg)
-    if a:0
-      return a:1
-    endif
-    return ''
+    return default
   endif
 
   while arg.rhs =~? '^<Plug>'
     let arg = maparg(arg.rhs, a:mode, 0, 1)
     if empty(arg)
-      if a:0
-        return a:1
-      endif
-      return ''
+      return default
     endif
   endwhile
 


### PR DESCRIPTION
Fixes #9