### PR TITLE
apparently fix completions not appearing immediately (fixes #17)

### DIFF
--- a/rplugin/python3/deoplete/sources/deoplete_clang2.py
+++ b/rplugin/python3/deoplete/sources/deoplete_clang2.py
@@ -121,7 +121,6 @@ class Source(Base):
     def __init__(self, nvim):
         super(Source, self).__init__(nvim)
         self.clang_path = ''
-        self.min_pattern_length = 0
         self.nvim = nvim
         self.name = 'clang2'
         self.mark = '[clang]'


### PR DESCRIPTION
this huge fix appears to make completions show up immediately again. as far as suspicion goes, it appears to be a conflict caused by deoplete invoking the plugin as soon as anything is typed (min_patter_length==0) and the gather_candidates refusing to find anything until there's at least two characters

I might be mistaken about the intent of this, in particular since the problem seems to only have started recently or only affects very few people, but it fixed it on my system.