### PR TITLE
Add support for "arguments" in database

### DIFF
--- a/rplugin/python3/deoplete/sources/deoplete_clang2.py
+++ b/rplugin/python3/deoplete/sources/deoplete_clang2.py
@@ -350,8 +350,16 @@ class Source(Base):
                 for entry in json.load(fp):
                     directory = entry.get('directory', cwd)
                     file, ext = os.path.splitext(entry.get('file', ''))
+
+                    if 'command' in entry:
+                        command = entry.get('command')
+                    elif 'arguments' in entry:
+                        command = ' '.join(entry.get('arguments'))
+                    else:
+                        raise Exception('Either "command" or "arguments" is required in compilation database')
+
                     for item in re.finditer(r'(-[IDFW]|' + flag_pattern +
-                                            ')\s*(\S+)', entry.get('command')):
+                                            ')\s*(\S+)', command):
                         flag = item.group(1)
                         val = item.group(2)
 


### PR DESCRIPTION
Compilation databases supports both `command` and `arguments` but deoplete-clang2 doesn't. This commit adds support for `arguments`. `command` is the first choice, `arguments` is second, and if neither is in the database an exception is raised. This priority might be worth documenting somewhere. Maybe a warning should be given if both are supplied rather than silently ignoring `arguments`, but that's debatable.