### PR TITLE
Fixed issue #32

### DIFF
--- a/autoload/clang2.vim
+++ b/autoload/clang2.vim
@@ -151,7 +151,7 @@ endfunction
 
 function! s:select_placeholder(mode, dir) abort
   let [p1, p2] = s:find_placeholder(a:dir)
-  if empty(p1) || empty(p2)
+  if empty(p1) || empty(p2) || (pumvisible())
     if mode() =~? 's\|v' || a:dir == 0
       return ''
     endif


### PR DESCRIPTION
This seems to fix the issue of the placeholder taking precedence over navigation of the auto-completion popup. I haven't worked with vimscript before, so it would probably be good to make sure I didn't break any edge cases, but as far as I can tell, it works.